### PR TITLE
Adding 'SKIP_MODULES' to VALID_SETTINGS

### DIFF
--- a/rest_framework_roles/parsing.py
+++ b/rest_framework_roles/parsing.py
@@ -8,7 +8,7 @@ from rest_framework_roles.exceptions import Misconfigured
 from rest_framework_roles import decorators
 
 
-VALID_SETTINGS = {"ROLES"}
+VALID_SETTINGS = {"ROLES", "SKIP_MODULES"}
 REQUIRED_SETTINGS = {"ROLES"}
 
 


### PR DESCRIPTION
I found that SKIP_MODULES is missing from VALID_SETTINGS and thus renders it useless.